### PR TITLE
fix: concurrency issues due to bad design #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ tmp/
 fly.toml
 
 .DS_Store
+
+.vscode/

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.21.3
 
 require (
 	github.com/PagerDuty/go-pagerduty v1.8.0
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/gofiber/fiber/v2 v2.52.2
 	github.com/grongor/panicwatch v1.2.0
 	github.com/jxsl13/osfacts v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.3
 
 require (
 	github.com/PagerDuty/go-pagerduty v1.8.0
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/gofiber/fiber/v2 v2.52.2
 	github.com/grongor/panicwatch v1.2.0
 	github.com/jxsl13/osfacts v0.4.0

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -1,9 +1,12 @@
 package monitoring
 
 import (
+	"encoding/base64"
+	"fmt"
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/equals215/deepsentinel/alerting"
 	"github.com/equals215/deepsentinel/config"
 	log "github.com/sirupsen/logrus"
@@ -52,50 +55,95 @@ type probeObject struct {
 
 type probeList struct {
 	sync.Mutex
-	p map[string]*probeObject
+	p           map[string]*probeObject
+	probesNames *[]string
 }
 
-var probes *probeList
+func CreateProbeList() *probeList {
+	probesNames := make([]string, 0)
+	return &probeList{
+		p:           make(map[string]*probeObject),
+		probesNames: &probesNames,
+	}
+}
 
 // Handle function handles the payload from the API server
-func Handle(channel chan *Payload) {
+func (probes *probeList) Handle(channel chan Payload) {
 	log.Debug("Starting monitoring.Handle")
-	probes = &probeList{
-		p: make(map[string]*probeObject),
-	}
+	// if probes != nil {
+	// 	log.Fatal("probes already initialized, this should never happen, please open an issue https://github.com/equals215/deepsentinel/issues/new")
+	// }
 	for {
 		select {
 		case receivedPayload := <-channel:
 			probes.Lock()
-			if probe, ok := probes.p[receivedPayload.Machine]; ok {
-				if receivedPayload.MachineStatus == "delete" {
+			log.Infof("probesNames: %v\n", probes.probesNames)
+			spew.Dump(probes)
+			payload := &receivedPayload
+			spew.Dump(payload)
+			// ONLY FOR TESTING SHOULD BE DELETED
+			// ONLY FOR TESTING SHOULD BE DELETED
+			if len(probes.p) > 2 {
+				log.WithFields(log.Fields{
+					"probes": probes.p,
+				}).Info("Probes")
+				spew.Dump(probes)
+				for _, probeName := range *probes.probesNames {
+					log.WithFields(log.Fields{
+						"probe": probeName,
+						"hexa":  fmt.Sprintf("%x", probeName),
+						"b64":   base64.StdEncoding.EncodeToString([]byte(probeName)),
+					}).Info("Probes")
+				}
+				log.Fatalf("Too many probes: %d", len(probes.p))
+			}
+			// ONLY FOR TESTING SHOULD BE DELETED
+			// ONLY FOR TESTING SHOULD BE DELETED
+			if probe, ok := probes.p[payload.Machine]; ok {
+				if payload.MachineStatus == "delete" {
 					// Delete the probe
 					log.WithFields(log.Fields{
 						"probe":   probe.name,
-						"machine": receivedPayload.Machine,
+						"machine": payload.Machine,
 					}).Info("Deleting probe")
 					probe.stop <- true
 					close(probe.data)
 					close(probe.stop)
-					delete(probes.p, receivedPayload.Machine)
+					delete(probes.p, payload.Machine)
 					probes.Unlock()
+					log.Info("—————————————————————————————————————————————————————————————————————")
 					continue
 				}
 				// Send the payload to the probe
-				probe.data <- receivedPayload
+				// probe.data <- payload
 				probes.Unlock()
+				log.Info("—————————————————————————————————————————————————————————————————————")
 				continue
 			} else {
+				// ONLY FOR TESTING SHOULD BE DELETED
+				// ONLY FOR TESTING SHOULD BE DELETED
+				for _, probeName := range *probes.probesNames {
+					log.Infof("payload.machine=%s, probeName=%s\n", payload.Machine, probeName)
+					if payload.Machine == probeName {
+						log.WithFields(log.Fields{
+							"gotMachine":      payload.Machine,
+							"existingMachine": probeName,
+						}).Fatalf("Probes")
+					}
+				}
+				spew.Dump(payload)
+				// ONLY FOR TESTING SHOULD BE DELETED
+				// ONLY FOR TESTING SHOULD BE DELETED
 				// Create a new probe
 				probe := &probeObject{
-					name:       receivedPayload.Machine,
-					data:       make(chan *Payload),
+					name:       payload.Machine,
+					data:       make(chan *Payload, 1),
 					stop:       make(chan bool),
 					status:     normal,
 					counter:    0,
 					lastNormal: time.Now(),
 					timeSerieHead: &timeSerieNode{
-						timestamp: receivedPayload.Timestamp,
+						timestamp: payload.Timestamp,
 						services:  make(map[string]*serviceStatus),
 						previous:  nil,
 					},
@@ -103,15 +151,18 @@ func Handle(channel chan *Payload) {
 					timeSerieMutex: sync.Mutex{},
 				}
 
-				probes.p[receivedPayload.Machine] = probe
+				probes.p[payload.Machine] = probe
+				newProbesNames := append(*probes.probesNames, payload.Machine)
+				probes.probesNames = &newProbesNames
 				log.WithFields(log.Fields{
 					"probe":   probe.name,
-					"machine": receivedPayload.Machine,
+					"machine": payload.Machine,
 					"status":  probe.status,
 				}).Info("Starting probe thread")
 				go probe.work()
-				probe.data <- receivedPayload
+				// probe.data <- payload
 				probes.Unlock()
+				log.Info("—————————————————————————————————————————————————————————————————————")
 				continue
 			}
 		}

--- a/monitoring/timeserie.go
+++ b/monitoring/timeserie.go
@@ -51,13 +51,13 @@ type probeTimeSerie struct {
 }
 
 func (p *probeObject) workServices(payload *Payload) {
-	p.timeSerieMutex.Lock()
+	p.timeSerie.Lock()
 	p.storePayload(payload)
-	if p.timeSerieSize > trimTimeSeriesThreshold {
+	if p.timeSerie.size > trimTimeSeriesThreshold {
 		go p.trimTimeSerie()
 	}
 	p.checkAlert()
-	p.timeSerieMutex.Unlock()
+	p.timeSerie.Unlock()
 }
 
 func (p *probeObject) storePayload(payload *Payload) {
@@ -76,8 +76,8 @@ func (p *probeObject) storePayload(payload *Payload) {
 			}).Error("Invalid status string in payload, defaulting to fail")
 		}
 
-		if p.timeSerieHead != nil {
-			prevServiceStatus, ok := p.timeSerieHead.services[service]
+		if p.timeSerie.head != nil {
+			prevServiceStatus, ok := p.timeSerie.head.services[service]
 			if ok && prevServiceStatus.status == parsedStatus && prevServiceStatus.status != pass {
 				tempCount = prevServiceStatus.count + 1
 			}
@@ -100,32 +100,32 @@ func (p *probeObject) storePayload(payload *Payload) {
 	newNode := &timeSerieNode{
 		timestamp: payload.Timestamp,
 		services:  tempServiceStatus,
-		previous:  p.timeSerieHead,
+		previous:  p.timeSerie.head,
 	}
 
-	p.timeSerieHead = newNode
-	p.timeSerieSize++
+	p.timeSerie.head = newNode
+	p.timeSerie.size++
 
 	log.WithFields(log.Fields{
 		"probe":   p.name,
 		"machine": payload.Machine,
 		"status":  p.status,
-		"size":    p.timeSerieSize,
+		"size":    p.timeSerie.size,
 	}).Trace("Payload stored in timeserie")
 }
 
 func (p *probeObject) trimTimeSerie() {
-	p.timeSerieMutex.Lock()
-	defer p.timeSerieMutex.Unlock()
+	p.timeSerie.Lock()
+	defer p.timeSerie.Unlock()
 
 	log.WithFields(log.Fields{
 		"probe": p.name,
-		"size":  p.timeSerieSize,
+		"size":  p.timeSerie.size,
 	}).Trace("Trimming timeserie")
 
 	count := 0
 	historicalAllPass := true
-	currentNode := p.timeSerieHead
+	currentNode := p.timeSerie.head
 	for currentNode != nil {
 		for _, service := range currentNode.services {
 			if service.status != pass {
@@ -144,53 +144,53 @@ func (p *probeObject) trimTimeSerie() {
 	}
 
 	if historicalAllPass {
-		p.timeSerieHead.previous = nil
-		p.timeSerieSize = 1
+		p.timeSerie.head.previous = nil
+		p.timeSerie.size = 1
 		log.WithFields(log.Fields{
 			"probe": p.name,
-			"size":  p.timeSerieSize,
+			"size":  p.timeSerie.size,
 		}).Trace("All historical data is pass trimmed timeserie to latest node")
 		return
 	}
 
 	if count >= trimTimeSeriesThreshold {
-		currentNode = p.timeSerieHead
+		currentNode = p.timeSerie.head
 		for i := 0; i < trimTimeSeriesThreshold-1; i++ {
 			currentNode = currentNode.previous
 		}
 		currentNode.previous = nil
-		p.timeSerieSize = trimTimeSeriesThreshold
+		p.timeSerie.size = trimTimeSeriesThreshold
 		log.WithFields(log.Fields{
 			"probe": p.name,
-			"size":  p.timeSerieSize,
+			"size":  p.timeSerie.size,
 		}).Trace("Trimmed timeserie to last 10 nodes")
 		return
 	}
 
 	if currentNode != nil {
 		currentNode.previous = nil
-		p.timeSerieSize = count
+		p.timeSerie.size = count
 		log.WithFields(log.Fields{
 			"probe": p.name,
-			"size":  p.timeSerieSize,
+			"size":  p.timeSerie.size,
 		}).Trace("Trimmed timeserie to node with first non-pass status")
 		return
 	}
 
-	p.timeSerieSize = 0
-	p.timeSerieHead = nil
+	p.timeSerie.size = 0
+	p.timeSerie.head = nil
 	log.WithFields(log.Fields{
 		"probe": p.name,
-		"size":  p.timeSerieSize,
+		"size":  p.timeSerie.size,
 	}).Error("Trimmed timeserie to empty")
 }
 
 func (p *probeObject) checkAlert() {
-	if p.timeSerieHead == nil {
+	if p.timeSerie.head == nil {
 		return
 	}
 
-	for service, status := range p.timeSerieHead.services {
+	for service, status := range p.timeSerie.head.services {
 		var alertingStatus string
 		alert := false
 

--- a/monitoring/timeserie.go
+++ b/monitoring/timeserie.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/equals215/deepsentinel/alerting"
@@ -41,6 +42,12 @@ type timeSerieNode struct {
 	timestamp time.Time
 	services  map[string]*serviceStatus
 	previous  *timeSerieNode
+}
+
+type probeTimeSerie struct {
+	sync.Mutex
+	head *timeSerieNode
+	size int
 }
 
 func (p *probeObject) workServices(payload *Payload) {

--- a/server/cmd.go
+++ b/server/cmd.go
@@ -6,7 +6,6 @@ import (
 	"github.com/equals215/deepsentinel/alerting"
 	"github.com/equals215/deepsentinel/config"
 	"github.com/equals215/deepsentinel/monitoring"
-	"github.com/grongor/panicwatch"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -29,25 +28,26 @@ func Cmd(rootCmd *cobra.Command) {
 			log.Infof("————————————")
 
 			config.PrintServerConfig()
-			payloadChannel := make(chan *monitoring.Payload, 1)
-			go monitoring.Handle(payloadChannel)
+			payloadChannel := make(chan monitoring.Payload)
+			probes := monitoring.CreateProbeList()
+			go probes.Handle(payloadChannel)
 
 			addr := fmt.Sprintf("%s:%d", config.Server.ListeningAddress, config.Server.Port)
 			newServer(payloadChannel).Listen(addr)
 			//Start panicwatch to catch panics
-			err := panicwatch.Start(panicwatch.Config{
-				OnPanic: func(p panicwatch.Panic) {
-					alerting.ServerAlert("deepsentinel", "server", "panic")
-				},
-				OnWatcherDied: func(err error) {
-					log.Error("panic watcher process died")
-					alerting.ServerAlert("deepsentinel", "panicwatcher", "low")
-				},
-			})
-			if err != nil {
-				log.Fatalf("failed to start panicwatch: %s", err.Error())
-			}
-			log.Info("Panicwatch started")
+			// err := panicwatch.Start(panicwatch.Config{
+			// 	OnPanic: func(p panicwatch.Panic) {
+			// 		alerting.ServerAlert("deepsentinel", "server", "panic")
+			// 	},
+			// 	OnWatcherDied: func(err error) {
+			// 		log.Error("panic watcher process died")
+			// 		alerting.ServerAlert("deepsentinel", "panicwatcher", "low")
+			// 	},
+			// })
+			// if err != nil {
+			// 	log.Fatalf("failed to start panicwatch: %s", err.Error())
+			// }
+			// log.Info("Panicwatch started")
 		},
 	}
 	serverCmd.Flags().BoolVarP(&noAlerting, "no-alert", "", false, "Disable alerting")

--- a/server/server.go
+++ b/server/server.go
@@ -8,9 +8,10 @@ import (
 	"github.com/equals215/deepsentinel/monitoring"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/keyauth"
+	"github.com/gofiber/fiber/v2/utils"
 )
 
-func newServer(payloadChannel chan monitoring.Payload) *fiber.App {
+func newServer(payloadChannel chan *monitoring.Payload) *fiber.App {
 	app := fiber.New(fiber.Config{
 		AppName: "DeepSentinel API",
 	})
@@ -28,7 +29,7 @@ func newServer(payloadChannel chan monitoring.Payload) *fiber.App {
 	})
 
 	app.Post("/probe/:machine/report", func(c *fiber.Ctx) error {
-		machine := c.Params("machine")
+		machine := utils.CopyString(c.Params("machine"))
 
 		// This shouldn't happen, desgined to catch Fiber's bug if ever
 		if machine == "" {
@@ -58,12 +59,12 @@ func newServer(payloadChannel chan monitoring.Payload) *fiber.App {
 		parsedPayload.Timestamp = time.Now()
 		parsedPayload.Machine = strings.TrimSpace(machine)
 
-		payloadChannel <- *parsedPayload
+		payloadChannel <- parsedPayload
 		return c.SendStatus(fiber.StatusAccepted)
 	})
 
 	app.Delete("/probe/:machine", func(c *fiber.Ctx) error {
-		machine := c.Params("machine")
+		machine := utils.CopyString(c.Params("machine"))
 
 		// This shouldn't happen, desgined to catch Fiber's bug if ever
 		if machine == "" {
@@ -79,7 +80,7 @@ func newServer(payloadChannel chan monitoring.Payload) *fiber.App {
 			Timestamp:     time.Now(),
 		}
 
-		payloadChannel <- *parsedPayload
+		payloadChannel <- parsedPayload
 		return c.SendStatus(fiber.StatusAccepted)
 	})
 

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/equals215/deepsentinel/monitoring"
@@ -9,7 +10,7 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/keyauth"
 )
 
-func newServer(payloadChannel chan *monitoring.Payload) *fiber.App {
+func newServer(payloadChannel chan monitoring.Payload) *fiber.App {
 	app := fiber.New(fiber.Config{
 		AppName: "DeepSentinel API",
 	})
@@ -45,7 +46,7 @@ func newServer(payloadChannel chan *monitoring.Payload) *fiber.App {
 		}
 
 		parsedPayload := &monitoring.Payload{}
-		err := json.Unmarshal(c.Body(), &parsedPayload)
+		err := json.Unmarshal(c.Body(), parsedPayload)
 		if err != nil {
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 				"status":  "fail",
@@ -55,9 +56,9 @@ func newServer(payloadChannel chan *monitoring.Payload) *fiber.App {
 		}
 
 		parsedPayload.Timestamp = time.Now()
-		parsedPayload.Machine = machine
+		parsedPayload.Machine = strings.TrimSpace(machine)
 
-		payloadChannel <- parsedPayload
+		payloadChannel <- *parsedPayload
 		return c.SendStatus(fiber.StatusAccepted)
 	})
 
@@ -72,13 +73,13 @@ func newServer(payloadChannel chan *monitoring.Payload) *fiber.App {
 			})
 		}
 
-		payload := &monitoring.Payload{
-			Machine:       machine,
+		parsedPayload := &monitoring.Payload{
+			Machine:       strings.TrimSpace(machine),
 			MachineStatus: "delete",
 			Timestamp:     time.Now(),
 		}
 
-		payloadChannel <- payload
+		payloadChannel <- *parsedPayload
 		return c.SendStatus(fiber.StatusAccepted)
 	})
 


### PR DESCRIPTION
- made payloads passed from Fiber goroutines immutable using `github.com/gofiber/fiber/v2/utils.CopyString()`
- replaced home-made `map[string]*probeObject` by a `sync.Map` for enhanced thread safety
- sanitize machine name before passing the payload to avoid duplicate probes in case of string inconsistency