### PR TITLE
Refactor `monitoring` package

### DIFF
--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"sync"
+	"time"
 )
 
 type Probe struct {
@@ -15,14 +16,16 @@ type Data struct {
 
 type Operator struct {
 	sync.Mutex
-	workers map[int]chan *Data
-	In      chan *Data
+	workers     map[int]chan *Data
+	PollingFreq time.Duration
+	In          chan *Data
 }
 
 func Handle() *Operator {
 	operator := &Operator{
-		workers: make(map[int]chan *Data),
-		In:      make(chan *Data),
+		workers:     make(map[int]chan *Data),
+		PollingFreq: 5 * time.Second,
+		In:          make(chan *Data),
 	}
 	go func(operator *Operator) {
 		for {

--- a/monitoring/decision.go
+++ b/monitoring/decision.go
@@ -1,0 +1,1 @@
+package monitoring

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -53,6 +53,11 @@ type probeWorker struct {
 	headOperator *Operator
 }
 
+// Operator defines the handler for the monitoring
+// It contains the channel to receive the payload from the API server
+// It contains the map of the probes and the list of the probes
+// It contains the dashboard operator to inform the dashboard of the status of the probes
+// Everything that defines the monitoring event loop is here
 type Operator struct {
 	sync.Mutex
 	In                chan *Payload
@@ -83,7 +88,7 @@ func Handle(dashboardOperator *dashboard.Operator) *Operator {
 				}
 
 				operator.dashboardOperator.Lock()
-				operator.InformDashboard()
+				operator.informDashboard()
 				timer.Reset(operator.dashboardOperator.PollingFreq)
 				operator.dashboardOperator.Unlock()
 
@@ -135,7 +140,7 @@ func Handle(dashboardOperator *dashboard.Operator) *Operator {
 	return operator
 }
 
-func (o *Operator) InformDashboard() {
+func (o *Operator) informDashboard() {
 	dashboardPayload := &dashboard.Data{
 		Probes: make([]*dashboard.Probe, 0),
 	}

--- a/monitoring/timeserie.go
+++ b/monitoring/timeserie.go
@@ -31,17 +31,32 @@ func stringtoStatusType(str string) (statusType, error) {
 	return fail, errors.New("invalid status string")
 }
 
+func (s statusType) String() string {
+	statusStr := map[statusType]string{
+		pass: "pass",
+		warn: "warn",
+		fail: "fail",
+	}
+	return statusStr[s]
+}
+
 type serviceStatus struct {
 	status statusType
 	count  int
 }
 
+type servicesStatus map[string]*serviceStatus
+
 type timeSerieNode struct {
 	timestamp time.Time
-	services  map[string]*serviceStatus
+	services  servicesStatus
 	previous  *timeSerieNode
 }
 
+// probeTimeSerie is a mutexed linked list of timeSerieNode
+// It is used to store the status of the services
+// The head of the list is the latest status
+// It goes like : previous <- ... <- head
 type probeTimeSerie struct {
 	sync.Mutex
 	head *timeSerieNode
@@ -59,12 +74,11 @@ func (p *probeWorker) workServices(payload *Payload) {
 }
 
 func (p *probeWorker) storePayload(payload *Payload) {
-	tempServiceStatus := make(map[string]*serviceStatus)
-	tempCount := 0
+	tempServiceStatus := make(servicesStatus)
 
 	for service, state := range payload.Services {
+		tempCount := 0
 		parsedStatus, err := stringtoStatusType(state)
-
 		if err != nil {
 			log.WithFields(log.Fields{
 				"probe":   p.name,
@@ -90,7 +104,7 @@ func (p *probeWorker) storePayload(payload *Payload) {
 			"probe":   p.name,
 			"machine": payload.Machine,
 			"service": service,
-			"status":  parsedStatus,
+			"status":  parsedStatus.String(),
 			"count":   tempCount,
 		}).Trace("Service status stored in timeserie")
 	}
@@ -119,24 +133,22 @@ func (p *probeWorker) checkAlert() {
 
 	for service, status := range p.timeSerie.head.services {
 		var alertingStatus string
-		alert := false
+		toAlert := false
 
 		lowThreshhold := config.Server.FailedToAlertedLowThreshold
 		highThreshhold := config.Server.FailedToAlertedLowThreshold + config.Server.AlertedLowToAlertedHighThreshold
 
-		if status.status == fail && status.count >= lowThreshhold && status.count < highThreshhold {
+		if status.status == fail && status.count == lowThreshhold && status.count < highThreshhold {
 			alertingStatus = "low"
-			alert = true
+			toAlert = true
 		} else if status.status == fail && status.count == highThreshhold {
 			alertingStatus = "high"
-			alert = true
-		} else if status.status == fail && status.count > highThreshhold {
-			alert = false
-		} else {
-			continue
+			toAlert = true
+		} else if status.status == fail {
+			toAlert = false
 		}
 
-		if alert {
+		if toAlert {
 			log.WithFields(log.Fields{
 				"probe":   p.name,
 				"machine": p.name,
@@ -145,7 +157,7 @@ func (p *probeWorker) checkAlert() {
 			}).Warnf("Service in fail status. Alerting %s", alertingStatus)
 			service = p.name + "-" + service
 			alerting.ServerAlert("service", service, alertingStatus)
-		} else if !alert && status.count%10 == 0 {
+		} else if status.status == fail && status.count > lowThreshhold && status.count%10 == 0 {
 			log.WithFields(log.Fields{
 				"probe":   p.name,
 				"machine": p.name,

--- a/monitoring/timeserie.go
+++ b/monitoring/timeserie.go
@@ -48,7 +48,7 @@ type probeTimeSerie struct {
 	size int
 }
 
-func (p *probeObject) workServices(payload *Payload) {
+func (p *probeWorker) workServices(payload *Payload) {
 	p.timeSerie.Lock()
 	p.storePayload(payload)
 	if p.timeSerie.size > trimTimeSeriesThreshold {
@@ -58,7 +58,7 @@ func (p *probeObject) workServices(payload *Payload) {
 	p.timeSerie.Unlock()
 }
 
-func (p *probeObject) storePayload(payload *Payload) {
+func (p *probeWorker) storePayload(payload *Payload) {
 	tempServiceStatus := make(map[string]*serviceStatus)
 	tempCount := 0
 
@@ -112,7 +112,7 @@ func (p *probeObject) storePayload(payload *Payload) {
 	}).Trace("Payload stored in timeserie")
 }
 
-func (p *probeObject) checkAlert() {
+func (p *probeWorker) checkAlert() {
 	if p.timeSerie.head == nil {
 		return
 	}

--- a/monitoring/timeserie_trim.go
+++ b/monitoring/timeserie_trim.go
@@ -4,7 +4,7 @@ import log "github.com/sirupsen/logrus"
 
 const trimTimeSeriesThreshold = 100
 
-func (p *probeObject) trimTimeSerie() {
+func (p *probeWorker) trimTimeSerie() {
 	p.timeSerie.Lock()
 	defer p.timeSerie.Unlock()
 
@@ -55,7 +55,7 @@ func (p *probeObject) trimTimeSerie() {
 	}
 }
 
-func (p *probeObject) trimToLastNode() {
+func (p *probeWorker) trimToLastNode() {
 	p.timeSerie.head.previous = nil
 	p.timeSerie.size = 1
 	log.WithFields(log.Fields{
@@ -65,7 +65,7 @@ func (p *probeObject) trimToLastNode() {
 	return
 }
 
-func (p *probeObject) trimToNode(count int) {
+func (p *probeWorker) trimToNode(count int) {
 	currentNode := p.timeSerie.head
 	for i := 0; i < count-1; i++ {
 		currentNode = currentNode.previous
@@ -79,7 +79,7 @@ func (p *probeObject) trimToNode(count int) {
 	return
 }
 
-func (p *probeObject) trimToGivenNode(currentNode *timeSerieNode, count int) {
+func (p *probeWorker) trimToGivenNode(currentNode *timeSerieNode, count int) {
 	currentNode.previous = nil
 	p.timeSerie.size = count
 	log.WithFields(log.Fields{

--- a/server/server.go
+++ b/server/server.go
@@ -18,7 +18,7 @@ import (
 //go:embed static/*
 var dashboardStatic embed.FS
 
-func newServer(payloadChannel chan *monitoring.Payload, dashboardOperator *dashboard.Operator) *fiber.App {
+func newServer(monitoringOperator *monitoring.Operator, dashboardOperator *dashboard.Operator) *fiber.App {
 	app := fiber.New(fiber.Config{
 		AppName: "DeepSentinel API",
 	})
@@ -28,11 +28,11 @@ func newServer(payloadChannel chan *monitoring.Payload, dashboardOperator *dashb
 	app.Get("/health", getHealthHandler)
 
 	app.Post("/probe/:machine/report", func(c *fiber.Ctx) error {
-		return postProbeReportHandler(c, payloadChannel)
+		return postProbeReportHandler(c, monitoringOperator.In)
 	})
 
 	app.Delete("/probe/:machine", func(c *fiber.Ctx) error {
-		return deleteProbeHandler(c, payloadChannel)
+		return deleteProbeHandler(c, monitoringOperator.In)
 	})
 
 	if dashboardOperator != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -37,7 +37,10 @@ func TestNewServer(t *testing.T) {
 			_ = payload
 		}
 	}()
-	s := newServer(payloadTestChan, dashboardOperator)
+
+	monitoringOperator := monitoring.Handle(dashboardOperator)
+
+	s := newServer(monitoringOperator, dashboardOperator)
 	// Test if the server is created
 	assert.NotNil(t, s, "newServer() returned nil")
 


### PR DESCRIPTION
* The monitoring routine is now working with an operator pattern like the dashboard, which enable us to control the basic functions of monitoring inside other packages such as server
* To my knowledge it didn't introduce any race-cond as the operator is mutexed and locked for every read/write operation on non-mutexed field
* Also nil pointer deref should happen as the pointers susceptible of being nil are checked

Gotta work on :
- [ ] Clarifying timeserie flow
- [ ] Refactor timeserie code
  - [ ] Do it well
- [ ] Create an alerting decision engine based on config.*Threshold values (good idea?)